### PR TITLE
Allow database name to be configured outside of connection string

### DIFF
--- a/src/NServiceBus.Persistence.MongoDb/MongoDbSettingsExtensions.cs
+++ b/src/NServiceBus.Persistence.MongoDb/MongoDbSettingsExtensions.cs
@@ -24,5 +24,12 @@ namespace NServiceBus.Persistence.MongoDB
             return cfg;
         }
 
+        public static PersistenceExtentions<MongoDbPersistence> SetDatabaseName(
+            this PersistenceExtentions<MongoDbPersistence> cfg, string databaseName)
+        {
+            cfg.GetSettings().Set(MongoPersistenceSettings.DatabaseName, databaseName);
+            return cfg;
+        }
+
     }
 }


### PR DESCRIPTION
Motivation: Need to be able to specify a connection string for MongoDB server that does not include the database, in order to access default admin account (the only account automatically created when box is provisioned).
Changes:
-add SetDatabaseName function to MongoDbSettingsExtensions
-add DatabaseName constant to MongoPersistenceSettings
-reorganized the MongoDbStorage Setup function and ConfigureMongoDbPersistence extension methods to accomdate new scenarios
TODO:
-allow database name to be pulled directly from config, add default config name