### PR TITLE
Persistence collections should check whether indexes already exist before trying to create them

### DIFF
--- a/src/NServiceBus.Persistence.MognoDb.Tests/Database/MongoFixture.cs
+++ b/src/NServiceBus.Persistence.MognoDb.Tests/Database/MongoFixture.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Configuration;
+using System.Globalization;
+using MongoDB.Driver;
+using NServiceBus.Persistence.MongoDB.Database;
+using NUnit.Framework;
+
+namespace NServiceBus.Persistence.MognoDb.Tests.Database
+{
+    public class MongoFixture
+    {
+        private const string MongoTestCollectionName = "MongoTestDocumentCollection";
+        private IMongoCollection<MongoTestDocument> _storage;
+        private IMongoDatabase _database;
+        private MongoClient _client;
+        private readonly string _databaseName = "Test_" + DateTime.Now.Ticks.ToString(CultureInfo.InvariantCulture);
+
+        [SetUp]
+        public void SetupContext()
+        {
+            var connectionString = ConfigurationManager.ConnectionStrings["MongoDB"].ConnectionString;
+
+            _client = new MongoClient(connectionString);
+            _database = _client.GetDatabase(_databaseName);
+            _storage = _database.GetCollection<MongoTestDocument>(MongoTestCollectionName);
+
+            FillCollection();
+        }
+
+        protected IMongoCollection<MongoTestDocument> Storage => _storage;
+
+        private void FillCollection()
+        {
+            _storage.InsertOne(new MongoTestDocument()
+            {
+                Property1 = Guid.NewGuid().ToString(),
+                Property2 = Guid.NewGuid().ToString()
+            });
+        }
+
+        [TearDown]
+        public void TeardownContext() => _client.DropDatabase(_databaseName);
+    }
+}

--- a/src/NServiceBus.Persistence.MognoDb.Tests/Database/MongoTestDocument.cs
+++ b/src/NServiceBus.Persistence.MognoDb.Tests/Database/MongoTestDocument.cs
@@ -1,0 +1,14 @@
+﻿using MongoDB.Bson;
+
+namespace NServiceBus.Persistence.MognoDb.Tests.Database
+{
+    public class MongoTestDocument
+    {
+        public ObjectId Id { get; set; }
+
+        public string Property1 { get; set; }
+
+        public string Property2 { get; set; }
+
+    }
+}

--- a/src/NServiceBus.Persistence.MognoDb.Tests/Database/When_ensure_indexes_exist.cs
+++ b/src/NServiceBus.Persistence.MognoDb.Tests/Database/When_ensure_indexes_exist.cs
@@ -1,0 +1,118 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using NServiceBus.Persistence.MongoDB.Database;
+using NUnit.Framework;
+
+namespace NServiceBus.Persistence.MognoDb.Tests.Database
+{
+    [TestFixture]
+    public class When_ensuring_indexes :MongoFixture
+    {
+        private const string IndexName = "name";
+        private const string BsonDocumentKey = "key";
+        private const string UniquenessKey = "unique";
+        private const string MongoIndexByDefault = "_id_";
+        private readonly BsonDocument _testIndex = new BsonDocument { { nameof(MongoTestDocument.Property1), 1 } };
+        private readonly BsonDocument _testCompositeIndex = new BsonDocument
+        {
+            {nameof(MongoTestDocument.Property1), 1},
+            {nameof(MongoTestDocument.Property2), 1}
+        };
+
+        private List<BsonDocument> StorageIndexes => Storage.Indexes.IndexesToList().GetAwaiter().GetResult();
+
+        [Test]
+        public Task Should_return_custom_index()
+        {
+            var indexToCreate = new BsonDocument { { nameof(MongoTestDocument.Property2), 1 } };
+            Storage.Indexes.CreateOne(new BsonDocumentIndexKeysDefinition<MongoTestDocument>(indexToCreate));
+            var indexes = Storage.Indexes.IndexesToList().GetAwaiter().GetResult();
+
+            //mongo collection always has _id_ index by default
+            Assert.AreEqual(2, indexes.Count);
+            Assert.AreEqual(indexToCreate, indexes.First(i=>i[IndexName] != MongoIndexByDefault)[BsonDocumentKey]);
+
+            return Task.FromResult(false);
+        }
+
+
+
+        [Test]
+        public Task Should_create_nonunique_index()
+        {
+            Storage.Indexes.EnsureIndex(_testIndex).Wait();
+
+            var indexes = Storage.Indexes.IndexesToList().GetAwaiter().GetResult();
+            Assert.AreEqual(2, indexes.Count);
+
+            var createdIndex = indexes.First(i => i[IndexName] != MongoIndexByDefault);
+            Assert.AreEqual(_testIndex, createdIndex[BsonDocumentKey]);
+            Assert.IsFalse(createdIndex.Contains(UniquenessKey));
+
+            return Task.FromResult(false);
+        }
+
+        [Test]
+        public Task Should_not_create_index()
+        {
+            Storage.Indexes.CreateOne(new BsonDocumentIndexKeysDefinition<MongoTestDocument>(_testIndex),
+                new CreateIndexOptions {Unique = true});
+            Assert.AreEqual(2, StorageIndexes.Count);
+
+            Storage.Indexes.EnsureIndex(_testIndex, new CreateIndexOptions { Unique = true }).Wait();
+            Assert.AreEqual(2, StorageIndexes.Count);
+            
+            return Task.FromResult(false);
+        }
+
+        [Test]
+        public Task Should_recreate_unique_index_on_same_field()
+        {
+            Storage.Indexes.CreateOne(new BsonDocumentIndexKeysDefinition<MongoTestDocument>(_testIndex));
+
+            Storage.Indexes.EnsureIndex(_testIndex, new CreateIndexOptions {Unique = true}).Wait();
+            
+            Assert.AreEqual(2, StorageIndexes.Count);
+            var createdIndex = StorageIndexes.First(i => i[IndexName] != MongoIndexByDefault);
+            Assert.AreEqual(_testIndex, createdIndex[BsonDocumentKey]);
+            Assert.IsTrue(createdIndex[UniquenessKey].ToBoolean());
+
+            return Task.FromResult(false);
+        }
+
+        [Test]
+        public Task Should_recreate_unique_index_on_same_field_with_default_name()
+        {
+            Storage.Indexes.CreateOne(new BsonDocumentIndexKeysDefinition<MongoTestDocument>(_testIndex),
+                new CreateIndexOptions() {Name = "custom_index_name"});
+            var indexNames = StorageIndexes.Select(index=>index[IndexName]);
+
+            Storage.Indexes.EnsureIndex(_testIndex, new CreateIndexOptions { Unique = true }).Wait();
+            
+            Assert.AreEqual(2, StorageIndexes.Count);
+            var createdIndex = StorageIndexes.First(i => !indexNames.Contains(i[IndexName]));
+            Assert.AreEqual(_testIndex, createdIndex[BsonDocumentKey]);
+            Assert.IsTrue(createdIndex[UniquenessKey].ToBoolean());
+
+            return Task.FromResult(false);
+        }
+
+        [Test]
+        public Task Should_create_composite_index()
+        {
+            Storage.Indexes.CreateOne(new BsonDocumentIndexKeysDefinition<MongoTestDocument>(_testIndex));
+            var indexNames = StorageIndexes.Select(index => index[IndexName]);
+            Storage.Indexes.EnsureIndex(_testCompositeIndex, new CreateIndexOptions { Unique = true }).Wait();
+
+            Assert.AreEqual(3, StorageIndexes.Count);
+            var createdIndex = StorageIndexes.First(i => !indexNames.Contains(i[IndexName]));
+            Assert.AreEqual(_testCompositeIndex, createdIndex[BsonDocumentKey]);
+            Assert.IsTrue(createdIndex[UniquenessKey].ToBoolean());
+
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.MognoDb.Tests/NServiceBus.Persistence.MognoDb.Tests.csproj
+++ b/src/NServiceBus.Persistence.MognoDb.Tests/NServiceBus.Persistence.MognoDb.Tests.csproj
@@ -67,6 +67,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Database\MongoFixture.cs" />
+    <Compile Include="Database\MongoTestDocument.cs" />
+    <Compile Include="Database\When_ensure_indexes_exist.cs" />
     <Compile Include="DataBus\AcceptanceTests.cs" />
     <Compile Include="DataBus\MongoFixture.cs" />
     <Compile Include="Gateway\MongoFixture.cs" />
@@ -101,6 +104,9 @@
       <Project>{b34dde97-b5f7-4fde-8144-ce0a5c886947}</Project>
       <Name>NServiceBus.Persistence.MongoDb</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/NServiceBus.Persistence.MongoDb/Database/BaseNsbMongoDbRepository.cs
+++ b/src/NServiceBus.Persistence.MongoDb/Database/BaseNsbMongoDbRepository.cs
@@ -31,8 +31,8 @@ namespace NServiceBus.Persistence.MongoDB.Database
 
         public Task EnsureUniqueIndex(Type entityType, string fieldName)
         {
-            return GetCollection(entityType).Indexes.CreateOneAsync(
-                new BsonDocumentIndexKeysDefinition<BsonDocument>(new BsonDocument(fieldName, 1)), new CreateIndexOptions() { Unique = true });
+            return GetCollection(entityType)
+                .Indexes.EnsureIndex(new BsonDocument(fieldName, 1), new CreateIndexOptions { Unique = true });
         }
 
         protected static T Deserialize<T>(BsonDocument doc)

--- a/src/NServiceBus.Persistence.MongoDb/Database/MongoDbStorage.cs
+++ b/src/NServiceBus.Persistence.MongoDb/Database/MongoDbStorage.cs
@@ -10,6 +10,7 @@ namespace NServiceBus.Persistence.MongoDB.Database
     {
         public const string SubscriptionCollectionName = "subscriptions";
         public const string DeduplicationCollectionName = "deduplication";
+        public const string TimeoutCollectionName = "timeouts";
         public const string SagaUniqueIdentityCollectionName = "saga_unique_ids";
     }
 
@@ -17,7 +18,7 @@ namespace NServiceBus.Persistence.MongoDB.Database
     {
         public const string ConnectionStringName = "MongoDbConnectionStringName";
         public const string ConnectionString = "MongoDbConnectionString";
-        
+
     }
 
     public static class MongoPersistenceConnectionStringNames
@@ -25,7 +26,7 @@ namespace NServiceBus.Persistence.MongoDB.Database
         public const string DefaultConnectionStringName = "NServiceBus/Persistence/MongoDB";
     }
 
-    
+
     public class MongoDbStorage : Feature
     {
         internal MongoDbStorage()
@@ -59,10 +60,10 @@ namespace NServiceBus.Persistence.MongoDB.Database
         {
             if (config == null) throw new ArgumentNullException(nameof(config));
             if (database == null) throw new ArgumentNullException(nameof(database));
-            
+
             config.RegisterSingleton(database);
-            
-            
+
+
             return config;
         }
 
@@ -109,7 +110,7 @@ namespace NServiceBus.Persistence.MongoDB.Database
             {
                 throw new ConfigurationErrorsException("Cannot configure Mongo Persister. No connection string was found");
             }
-            
+
             return MongoPersistenceWithConectionString(config, connectionString);
         }
     }

--- a/src/NServiceBus.Persistence.MongoDb/Database/MongoIndexEnsurenceManager.cs
+++ b/src/NServiceBus.Persistence.MongoDb/Database/MongoIndexEnsurenceManager.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace NServiceBus.Persistence.MongoDB.Database
+{
+    internal static class MongoIndexEnsurenceManager<T>
+    {
+        private const string UniquenessKey = "unique";
+        private const string IndexName = "name";
+        private const string BsonDocumentKey = "key";
+
+        private enum IndexExistence
+        {
+            Create,
+            Recreate,
+            None
+        }
+
+        private delegate Task IndexExistenceDelegate(
+            IMongoIndexManager<T> indexManager, BsonDocument key, CreateIndexOptions options,
+            IEnumerable<BsonDocument> indexes);
+
+        private static readonly Dictionary<IndexExistence, IndexExistenceDelegate> IndexExistenceHandlers = new Dictionary
+            <IndexExistence, IndexExistenceDelegate>()
+        {
+            {IndexExistence.Create, OnNoneIndex},
+            {IndexExistence.Recreate, OnDifferentOprionsIndex},
+            {IndexExistence.None, (manager, index, options, indexes) => Task.FromResult(false)}
+        };
+
+
+
+        public static async Task EnsureIndex(IMongoIndexManager<T> indexManager, BsonDocument indexToEnsure,
+            CreateIndexOptions options = null)
+        {
+            if (options == null)
+                options = new CreateIndexOptions();
+            var collectionIndexes = await indexManager.IndexesToList().ConfigureAwait(false);
+            var existence = IndexExists(collectionIndexes, indexToEnsure, options);
+            await IndexExistenceHandlers[existence].Invoke(indexManager, indexToEnsure, options, collectionIndexes).ConfigureAwait(false);
+        }
+
+        private static IndexExistence IndexExists(IEnumerable<BsonDocument> collectionIndexes, BsonDocument indexToEnsure,
+            CreateIndexOptions options)
+        {
+            var existingIndex = collectionIndexes.FirstOrDefault(index =>
+                index[BsonDocumentKey].Equals(indexToEnsure));
+
+            //no such index key -> create index
+            if (existingIndex == null)
+                return IndexExistence.Create;
+
+            //if nonunique index required, no matter unique/nonunique index was created before -> do nothing
+            //if unique index required and current index options are the same -> do nothing
+            if (!options.Unique.HasValue || !options.Unique.Value
+                || collectionIndexes.Any(
+                    index =>
+                        index[BsonDocumentKey].Equals(indexToEnsure) &&
+                        index.Contains(UniquenessKey)
+                        && index[UniquenessKey].AsBoolean == true))
+                return IndexExistence.None;
+
+            //collection has index on same fields with different options with name by default -> drop and create index
+            return IndexExistence.Recreate;
+        }
+
+
+        #region Existence handlers
+
+        /// <summary>
+        /// Handles Create index. Creates index.
+        /// </summary>
+        /// <param name="indexManager">Mongo index manager.</param>
+        /// <param name="indexToEnsure">Index to recreate.</param>
+        /// <param name="options">Options for creating an index.</param>
+        /// <param name="collectionIndexes">Set of collection indexes.</param>
+        /// <returns>Task to await index recreation.</returns>
+        private static Task OnNoneIndex(IMongoIndexManager<T> indexManager, BsonDocument indexToEnsure,
+            CreateIndexOptions options, IEnumerable<BsonDocument> collectionIndexes)
+        {
+            return indexManager.CreateOneAsync(new BsonDocumentIndexKeysDefinition<T>(indexToEnsure), options);
+        }
+
+        /// <summary>
+        /// Handles DifferentOprionsIndex. Drops and recreates index because it was created with different options.
+        /// </summary>
+        /// <param name="indexManager">Mongo index manager.</param>
+        /// <param name="indexToEnsure">Index to recreate.</param>
+        /// <param name="options">Options for creating an index.</param>
+        /// <param name="collectionIndexes">Set of collection indexes.</param>
+        /// <returns>Task to await index recreation.</returns>
+        private static async Task OnDifferentOprionsIndex(IMongoIndexManager<T> indexManager, BsonDocument indexToEnsure,
+            CreateIndexOptions options, IEnumerable<BsonDocument> collectionIndexes)
+        {
+            // index can have custom name
+            var indexName = collectionIndexes.First(index => index[BsonDocumentKey].Equals(indexToEnsure))[IndexName].ToString();
+
+            await indexManager.DropOneAsync(indexName).ConfigureAwait(false);
+
+            await
+                indexManager.CreateOneAsync(new BsonDocumentIndexKeysDefinition<T>(indexToEnsure), options)
+                    .ConfigureAwait(false);
+        }
+
+        #endregion
+
+    }
+}

--- a/src/NServiceBus.Persistence.MongoDb/Database/MongoIndexEnsurenceManager.cs
+++ b/src/NServiceBus.Persistence.MongoDb/Database/MongoIndexEnsurenceManager.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Persistence.MongoDB.Database
         private const string IndexName = "name";
         private const string BsonDocumentKey = "key";
 
-        private enum IndexExistence
+        private enum IndexEnsurenceAction
         {
             Create,
             Recreate,
@@ -23,12 +23,12 @@ namespace NServiceBus.Persistence.MongoDB.Database
             IMongoIndexManager<T> indexManager, BsonDocument key, CreateIndexOptions options,
             IEnumerable<BsonDocument> indexes);
 
-        private static readonly Dictionary<IndexExistence, IndexExistenceDelegate> IndexExistenceHandlers = new Dictionary
-            <IndexExistence, IndexExistenceDelegate>()
+        private static readonly Dictionary<IndexEnsurenceAction, IndexExistenceDelegate> IndexEnsurenceActionHandlers = new Dictionary
+            <IndexEnsurenceAction, IndexExistenceDelegate>()
         {
-            {IndexExistence.Create, OnNoneIndex},
-            {IndexExistence.Recreate, OnDifferentOprionsIndex},
-            {IndexExistence.None, (manager, index, options, indexes) => Task.FromResult(false)}
+            {IndexEnsurenceAction.Create, CreateIndex},
+            {IndexEnsurenceAction.Recreate, DropAndCreateIndex},
+            {IndexEnsurenceAction.None, (manager, index, options, indexes) => Task.FromResult(false)}
         };
 
 
@@ -39,11 +39,11 @@ namespace NServiceBus.Persistence.MongoDB.Database
             if (options == null)
                 options = new CreateIndexOptions();
             var collectionIndexes = await indexManager.IndexesToList().ConfigureAwait(false);
-            var existence = IndexExists(collectionIndexes, indexToEnsure, options);
-            await IndexExistenceHandlers[existence].Invoke(indexManager, indexToEnsure, options, collectionIndexes).ConfigureAwait(false);
+            var action = IndexExists(collectionIndexes, indexToEnsure, options);
+            await IndexEnsurenceActionHandlers[action].Invoke(indexManager, indexToEnsure, options, collectionIndexes).ConfigureAwait(false);
         }
 
-        private static IndexExistence IndexExists(IEnumerable<BsonDocument> collectionIndexes, BsonDocument indexToEnsure,
+        private static IndexEnsurenceAction IndexExists(IEnumerable<BsonDocument> collectionIndexes, BsonDocument indexToEnsure,
             CreateIndexOptions options)
         {
             var existingIndex = collectionIndexes.FirstOrDefault(index =>
@@ -51,7 +51,7 @@ namespace NServiceBus.Persistence.MongoDB.Database
 
             //no such index key -> create index
             if (existingIndex == null)
-                return IndexExistence.Create;
+                return IndexEnsurenceAction.Create;
 
             //if nonunique index required, no matter unique/nonunique index was created before -> do nothing
             //if unique index required and current index options are the same -> do nothing
@@ -61,38 +61,38 @@ namespace NServiceBus.Persistence.MongoDB.Database
                         index[BsonDocumentKey].Equals(indexToEnsure) &&
                         index.Contains(UniquenessKey)
                         && index[UniquenessKey].AsBoolean == true))
-                return IndexExistence.None;
+                return IndexEnsurenceAction.None;
 
             //collection has index on same fields with different options with name by default -> drop and create index
-            return IndexExistence.Recreate;
+            return IndexEnsurenceAction.Recreate;
         }
 
 
         #region Existence handlers
 
         /// <summary>
-        /// Handles Create index. Creates index.
+        /// Creates index.
         /// </summary>
         /// <param name="indexManager">Mongo index manager.</param>
         /// <param name="indexToEnsure">Index to recreate.</param>
         /// <param name="options">Options for creating an index.</param>
         /// <param name="collectionIndexes">Set of collection indexes.</param>
         /// <returns>Task to await index recreation.</returns>
-        private static Task OnNoneIndex(IMongoIndexManager<T> indexManager, BsonDocument indexToEnsure,
+        private static Task CreateIndex(IMongoIndexManager<T> indexManager, BsonDocument indexToEnsure,
             CreateIndexOptions options, IEnumerable<BsonDocument> collectionIndexes)
         {
             return indexManager.CreateOneAsync(new BsonDocumentIndexKeysDefinition<T>(indexToEnsure), options);
         }
 
         /// <summary>
-        /// Handles DifferentOprionsIndex. Drops and recreates index because it was created with different options.
+        /// Drops and recreates index because it was created with different options.
         /// </summary>
         /// <param name="indexManager">Mongo index manager.</param>
         /// <param name="indexToEnsure">Index to recreate.</param>
         /// <param name="options">Options for creating an index.</param>
         /// <param name="collectionIndexes">Set of collection indexes.</param>
         /// <returns>Task to await index recreation.</returns>
-        private static async Task OnDifferentOprionsIndex(IMongoIndexManager<T> indexManager, BsonDocument indexToEnsure,
+        private static async Task DropAndCreateIndex(IMongoIndexManager<T> indexManager, BsonDocument indexToEnsure,
             CreateIndexOptions options, IEnumerable<BsonDocument> collectionIndexes)
         {
             // index can have custom name

--- a/src/NServiceBus.Persistence.MongoDb/Database/MongoIndexManagerExtensions.cs
+++ b/src/NServiceBus.Persistence.MongoDb/Database/MongoIndexManagerExtensions.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace NServiceBus.Persistence.MongoDB.Database
+{
+    internal static class MongoIndexManagerExtensions
+    {
+        public static Task EnsureIndex<T>(this IMongoIndexManager<T> indexManager, BsonDocument indexToEnsure,
+            CreateIndexOptions options = null)
+        {
+            return MongoIndexEnsurenceManager<T>.EnsureIndex(indexManager, indexToEnsure, options);
+        }
+
+        public static async Task<List<BsonDocument>> IndexesToList<T>(this IMongoIndexManager<T> indexManager)
+        {
+            var indexesCursor = await indexManager.ListAsync().ConfigureAwait(false);
+            var indexes = await indexesCursor.ToListAsync().ConfigureAwait(false);
+            return indexes;
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.MongoDb/NServiceBus.Persistence.MongoDb.csproj
+++ b/src/NServiceBus.Persistence.MongoDb/NServiceBus.Persistence.MongoDb.csproj
@@ -67,7 +67,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Database\MongoIndexEnsurenceManager.cs" />
     <Compile Include="Database\MongoDbStorage.cs" />
+    <Compile Include="Database\MongoIndexManagerExtensions.cs" />
     <Compile Include="DataBus\GridFsDataBus.cs" />
     <Compile Include="DataBus\MongoDbDataBus.cs" />
     <Compile Include="DataBus\MongoDbDataBusPersistence.cs" />
@@ -87,6 +89,7 @@
     <Compile Include="Subscriptions\Subscription.cs" />
     <Compile Include="Subscriptions\SubscriptionPersister.cs" />
     <Compile Include="Timeout\MongoDbTimeoutStorage.cs" />
+    <Compile Include="Timeout\TimeoutEntity.cs" />
     <Compile Include="Timeout\TimeoutPersister.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NServiceBus.Persistence.MongoDb/Properties/AssemblyInfo.cs
+++ b/src/NServiceBus.Persistence.MongoDb/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("NServiceBus.Persistence.MongoDb")]
@@ -9,3 +10,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("7.0.0")]
 [assembly: AssemblyFileVersion("7.0.0")]
 [assembly: AssemblyInformationalVersion("7.0.0")]
+
+[assembly: InternalsVisibleTo("NServiceBus.Persistence.MognoDb.Tests")]

--- a/src/NServiceBus.Persistence.MongoDb/Timeout/MongoDbTimeoutStorage.cs
+++ b/src/NServiceBus.Persistence.MongoDb/Timeout/MongoDbTimeoutStorage.cs
@@ -19,9 +19,13 @@ namespace NServiceBus.Persistence.MongoDB.Timeout
         {
             context.Container.ConfigureComponent(b =>
             {
-                return new TimeoutPersister(context.Settings.EndpointName().ToString(), b.Build<IMongoDatabase>());
-                
+                var timeoutPersister = new TimeoutPersister(context.Settings.EndpointName().ToString(),
+                    b.Build<IMongoDatabase>());
+                timeoutPersister.Init();
+                return timeoutPersister;
+
             }, DependencyLifecycle.InstancePerCall);
+
         }
     }
 }

--- a/src/NServiceBus.Persistence.MongoDb/Timeout/TimeoutEntity.cs
+++ b/src/NServiceBus.Persistence.MongoDb/Timeout/TimeoutEntity.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Bson.Serialization.Options;
+using NServiceBus.Timeout.Core;
+
+namespace NServiceBus.Persistence.MongoDB.Timeout
+{
+    /// <summary>
+    /// MongoDB wrapper class for <see cref="TimeoutData"/>
+    /// </summary>
+    public class TimeoutEntity
+    {
+        /// <summary>
+        /// Id of this timeout.
+        /// </summary>
+        public virtual string Id { get; set; }
+
+        //TODO: Breaking change NSB v5 to v6 - was type NServiceBus.Address
+        /// <summary>
+        /// The address of the client who requested the timeout.
+        /// </summary>
+        public virtual string Destination { get; set; }
+
+        /// <summary>
+        /// The saga ID.
+        /// </summary>
+        public virtual Guid SagaId { get; set; }
+
+        /// <summary>
+        /// Additional state.
+        /// </summary>
+        public virtual byte[] State { get; set; }
+
+        /// <summary>
+        /// The time at which the saga ID expired.
+        /// </summary>
+        public virtual DateTime Time { get; set; }
+
+        /// <summary>
+        /// Store the headers to preserve them across timeouts.
+        /// </summary>
+        [BsonDictionaryOptions(DictionaryRepresentation.ArrayOfArrays)]
+        public virtual Dictionary<string, string> Headers { get; set; }
+
+        /// <summary>
+        /// Timeout endpoint name.
+        /// </summary>
+        public virtual string Endpoint { get; set; }
+
+        /// <summary>
+        ///     The timeout manager that owns this particular timeout
+        /// </summary>
+        public string OwningTimeoutManager { get; set; }
+
+        /// <summary>
+        /// The time when the timeout record was locked. If null then the record has not been locked.
+        /// </summary>
+        /// <remarks>
+        /// Timeout locks are only considered valid for 10 seconds, therefore if the LockDateTime is older than 10 seconds it is no longer valid.
+        /// </remarks>
+        public DateTime? LockDateTime { get; set; }
+
+        public TimeoutData ToTimeoutData()
+        {
+            return new TimeoutData
+            {
+                Destination = Destination,
+                Headers = Headers,
+                OwningTimeoutManager = OwningTimeoutManager,
+                SagaId = SagaId,
+                State = State,
+                Time = Time
+            };
+        }
+    }
+}


### PR DESCRIPTION
**Preface**
In our application we have some security restrictions for MongoDb users. 
When user connects to database his granted actions are: "insert", "remove", "update", "find". 
We don't want to grant to end user database management actions, such as "createIndex". DBA should create all necessary indexes from deployment script.
**Root of the problem**
In methods SagaPersister.Save(), SubscriptionPersister.Init(), TimeoutPersister.Add() I found index creation operation without checks whether index already exists. For example, when I try to work with timeouts persistence collection I see: 

> MongoDB.Driver.MongoCommandException: Command createIndexes failed: not authoried on DB_Name to execute command { createIndexes: "timeouts", ...}

because my user has no administrative privileges, but all indexes already exists in my database.
I have created static class MongoIndexEnsurenceManager to solve this problem. It is better to call EnsureIndex() method while persistence storage initializing, not every add/save command. Unlikely anyone drop your index after you create it.
In my opinion this code should be placed in MongoDB.Driver lib. I don't know why MongoDB developers haven't  such index manager extension.